### PR TITLE
Expand dataset to 5 countries, 10 leagues, 6 seasons

### DIFF
--- a/config/data_config.json
+++ b/config/data_config.json
@@ -12,6 +12,8 @@
       "competition_name": "Premier League",
       "league_code": "E0",
       "season_names": [
+        "2019/2020",
+        "2020/2021",
         "2021/2022",
         "2022/2023",
         "2023/2024",
@@ -24,6 +26,120 @@
       "competition_name": "Championship",
       "league_code": "E1",
       "season_names": [
+        "2019/2020",
+        "2020/2021",
+        "2021/2022",
+        "2022/2023",
+        "2023/2024",
+        "2024/2025"
+      ],
+      "division_level": 2
+    },
+    {
+      "country_name": "Germany",
+      "competition_name": "Bundesliga",
+      "league_code": "D1",
+      "season_names": [
+        "2019/2020",
+        "2020/2021",
+        "2021/2022",
+        "2022/2023",
+        "2023/2024",
+        "2024/2025"
+      ],
+      "division_level": 1
+    },
+    {
+      "country_name": "Germany",
+      "competition_name": "2. Bundesliga",
+      "league_code": "D2",
+      "season_names": [
+        "2019/2020",
+        "2020/2021",
+        "2021/2022",
+        "2022/2023",
+        "2023/2024",
+        "2024/2025"
+      ],
+      "division_level": 2
+    },
+    {
+      "country_name": "Spain",
+      "competition_name": "La Liga",
+      "league_code": "SP1",
+      "season_names": [
+        "2019/2020",
+        "2020/2021",
+        "2021/2022",
+        "2022/2023",
+        "2023/2024",
+        "2024/2025"
+      ],
+      "division_level": 1
+    },
+    {
+      "country_name": "Spain",
+      "competition_name": "Segunda Division",
+      "league_code": "SP2",
+      "season_names": [
+        "2019/2020",
+        "2020/2021",
+        "2021/2022",
+        "2022/2023",
+        "2023/2024",
+        "2024/2025"
+      ],
+      "division_level": 2
+    },
+    {
+      "country_name": "Italy",
+      "competition_name": "Serie A",
+      "league_code": "I1",
+      "season_names": [
+        "2019/2020",
+        "2020/2021",
+        "2021/2022",
+        "2022/2023",
+        "2023/2024",
+        "2024/2025"
+      ],
+      "division_level": 1
+    },
+    {
+      "country_name": "Italy",
+      "competition_name": "Serie B",
+      "league_code": "I2",
+      "season_names": [
+        "2019/2020",
+        "2020/2021",
+        "2021/2022",
+        "2022/2023",
+        "2023/2024",
+        "2024/2025"
+      ],
+      "division_level": 2
+    },
+    {
+      "country_name": "France",
+      "competition_name": "Ligue 1",
+      "league_code": "F1",
+      "season_names": [
+        "2019/2020",
+        "2020/2021",
+        "2021/2022",
+        "2022/2023",
+        "2023/2024",
+        "2024/2025"
+      ],
+      "division_level": 1
+    },
+    {
+      "country_name": "France",
+      "competition_name": "Ligue 2",
+      "league_code": "F2",
+      "season_names": [
+        "2019/2020",
+        "2020/2021",
         "2021/2022",
         "2022/2023",
         "2023/2024",
@@ -45,6 +161,8 @@
   ],
   "season_split": {
     "train": [
+      "2019/2020",
+      "2020/2021",
       "2021/2022",
       "2022/2023"
     ],

--- a/data/build_dataset.py
+++ b/data/build_dataset.py
@@ -337,6 +337,7 @@ def build_dataset(config):
     next_team_id = 1
 
     for competition_row in selected_rows:
+        country_name = competition_row.get("country_name", "Unknown")
         competition_name = competition_row["competition_name"]
         season_name = competition_row["season_name"]
         division_level = int(competition_row["division_level"])
@@ -422,6 +423,8 @@ def build_dataset(config):
             match_meta_records.append(
                 {
                     "match_id": match_id,
+                    "country_name": country_name,
+                    "league_code": league_code,
                     "season": season_name,
                     "league": competition_name,
                     "datetime_utc": match_row["datetime_utc"],


### PR DESCRIPTION
- add country_name/league_code to match_meta
- requested_competitions: add Germany D1/D2, Spain SP1/SP2, Italy I1/I2, France F1/F2
- extend all leagues back to 2019/2020 (from 2021/2022)
- season_split: train now includes 2019/2020 and 2020/2021
- match_meta now records country_name and league_code per record for downstream filtering

Dataset size: 3728 -> 23012 total matches; train 1864 -> 15423